### PR TITLE
Delete a ingredient from a product

### DIFF
--- a/backend/prisma/migrations/20230513175619_update_types_and_define_on_delete/migration.sql
+++ b/backend/prisma/migrations/20230513175619_update_types_and_define_on_delete/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `totalOrder` on the `orders` table. The data in that column could be lost. The data in that column will be cast from `Money` to `Decimal(10,2)`.
+  - You are about to alter the column `price` on the `products` table. The data in that column could be lost. The data in that column will be cast from `Money` to `Decimal(10,2)`.
+  - You are about to alter the column `totalTableAccount` on the `tablesAccount` table. The data in that column could be lost. The data in that column will be cast from `Money` to `Decimal(10,2)`.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ingredientsOnProducts" DROP CONSTRAINT "ingredientsOnProducts_ingredientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ingredientsOnProducts" DROP CONSTRAINT "ingredientsOnProducts_productId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "products" DROP CONSTRAINT "products_categoryId_fkey";
+
+-- AlterTable
+ALTER TABLE "orders" ALTER COLUMN "totalOrder" SET DATA TYPE DECIMAL(10,2);
+
+-- AlterTable
+ALTER TABLE "products" ALTER COLUMN "categoryId" DROP NOT NULL,
+ALTER COLUMN "price" SET DATA TYPE DECIMAL(10,2);
+
+-- AlterTable
+ALTER TABLE "tablesAccount" ALTER COLUMN "totalTableAccount" SET DATA TYPE DECIMAL(10,2);
+
+-- AddForeignKey
+ALTER TABLE "ingredientsOnProducts" ADD CONSTRAINT "ingredientsOnProducts_ingredientId_fkey" FOREIGN KEY ("ingredientId") REFERENCES "ingredients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ingredientsOnProducts" ADD CONSTRAINT "ingredientsOnProducts_productId_fkey" FOREIGN KEY ("productId") REFERENCES "products"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "products" ADD CONSTRAINT "products_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,10 +36,10 @@ model Ingredient {
 
 model IngredientsOnProducts {
   quantity     Int        @default(1)
-  Ingredients  Ingredient @relation(fields: [ingredientId], references: [id])
+  Ingredients  Ingredient @relation(fields: [ingredientId], references: [id], onDelete: Cascade)
   ingredientId String
 
-  Product   Product @relation(fields: [productId], references: [id])
+  Product   Product @relation(fields: [productId], references: [id], onDelete: Cascade)
   productId String
 
   @@id([productId, ingredientId])
@@ -55,8 +55,8 @@ model Product {
   description String?
   isActive    Boolean @default(true)
 
-  Category   Category @relation(fields: [categoryId], references: [id])
-  categoryId String
+  Category   Category? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
+  categoryId String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -50,7 +50,7 @@ model Product {
   id String @unique @default(uuid())
 
   name        String  @unique
-  price       Decimal @db.Money()
+  price       Decimal @db.Decimal(10, 2)
   urlImage    String?
   description String?
   isActive    Boolean @default(true)
@@ -96,7 +96,7 @@ model TableAccount {
   id String @unique @default(uuid())
 
   title             String
-  totalTableAccount Decimal   @db.Money()
+  totalTableAccount Decimal   @db.Decimal(10, 2)
   openAt            DateTime  @default(now())
   closedAt          DateTime?
 
@@ -127,7 +127,7 @@ model Order {
   id String @unique @default(uuid())
 
   productQuantity Int     @default(1)
-  totalOrder      Decimal @db.Money()
+  totalOrder      Decimal @db.Decimal(10, 2)
 
   TableAccount   TableAccount @relation(fields: [tableAccountId], references: [id])
   tableAccountId String

--- a/backend/src/modules/product/dto/delete-ingredient-from-a-product-dto.ts
+++ b/backend/src/modules/product/dto/delete-ingredient-from-a-product-dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class DeleteIngredientFromAProduct {
+  @IsNotEmpty()
+  @IsUUID()
+  ingredientId: string;
+}

--- a/backend/src/modules/product/factories/makeDeleteIngredientFromAProductUseCase.ts
+++ b/backend/src/modules/product/factories/makeDeleteIngredientFromAProductUseCase.ts
@@ -1,0 +1,17 @@
+import { PrismaProductsRepository } from '../repositories/prisma/prisma-products-repository';
+import { PrismaIngredientsRepository } from 'src/modules/ingredient/repositories/prisma/prisma-ingredients-repository';
+import DeleteIngredientFromAProductUseCase from '../use-cases/delete-ingredient-from-a-product';
+
+export function makeDeleteIngredientFromAProductUseCase() {
+  const productRepository = new PrismaProductsRepository();
+  const ingredientsRepository = new PrismaIngredientsRepository();
+
+  const deleteIngredientFromAProductUseCase =
+    new DeleteIngredientFromAProductUseCase(
+      productRepository,
+
+      ingredientsRepository,
+    );
+
+  return deleteIngredientFromAProductUseCase;
+}

--- a/backend/src/modules/product/factories/makeDeleteProduct.ts
+++ b/backend/src/modules/product/factories/makeDeleteProduct.ts
@@ -1,0 +1,8 @@
+import { PrismaProductsRepository } from '../repositories/prisma/prisma-products-repository';
+import DeleteProductUseCase from '../use-cases/delete';
+
+export function makeDeleteProductUseCase() {
+  const productRepository = new PrismaProductsRepository();
+
+  return new DeleteProductUseCase(productRepository);
+}

--- a/backend/src/modules/product/product.controller.ts
+++ b/backend/src/modules/product/product.controller.ts
@@ -20,6 +20,7 @@ import { makeFindOneByIdUseCase } from './factories/makeFindOneByIdUseCase';
 import { makeUpdateProductUseCase } from './factories/makeUpdateProductUseCase';
 import { UpdateProductDTO } from './dto/update-product-dto';
 import { makeDeleteProductUseCase } from './factories/makeDeleteProduct';
+import { makeDeleteIngredientFromAProductUseCase } from './factories/makeDeleteIngredientFromAProductUseCase';
 
 @Controller('products')
 export class ProductController {
@@ -68,5 +69,19 @@ export class ProductController {
     const deleteProductUseCase = makeDeleteProductUseCase();
 
     return await deleteProductUseCase.execute(id);
+  }
+
+  @Delete('ingredients/:productId')
+  async deleteIngredientFromAProduct(
+    @Param('productId') productId: string,
+    @Body() ingredientId: string,
+  ) {
+    const deleteIngredientFromAProductUseCase =
+      makeDeleteIngredientFromAProductUseCase();
+
+    return await deleteIngredientFromAProductUseCase.execute({
+      ingredientId,
+      productId,
+    });
   }
 }

--- a/backend/src/modules/product/product.controller.ts
+++ b/backend/src/modules/product/product.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
@@ -18,6 +19,7 @@ import { makeChangeProductAvailabilityUseCase } from './factories/makeChangeProd
 import { makeFindOneByIdUseCase } from './factories/makeFindOneByIdUseCase';
 import { makeUpdateProductUseCase } from './factories/makeUpdateProductUseCase';
 import { UpdateProductDTO } from './dto/update-product-dto';
+import { makeDeleteProductUseCase } from './factories/makeDeleteProduct';
 
 @Controller('products')
 export class ProductController {
@@ -59,5 +61,12 @@ export class ProductController {
     const findOneByIdUseCase = makeFindOneByIdUseCase();
 
     return await findOneByIdUseCase.execute(id);
+  }
+
+  @Delete(':id')
+  async delete(@Param('id') id: string) {
+    const deleteProductUseCase = makeDeleteProductUseCase();
+
+    return await deleteProductUseCase.execute(id);
   }
 }

--- a/backend/src/modules/product/product.controller.ts
+++ b/backend/src/modules/product/product.controller.ts
@@ -21,6 +21,7 @@ import { makeUpdateProductUseCase } from './factories/makeUpdateProductUseCase';
 import { UpdateProductDTO } from './dto/update-product-dto';
 import { makeDeleteProductUseCase } from './factories/makeDeleteProduct';
 import { makeDeleteIngredientFromAProductUseCase } from './factories/makeDeleteIngredientFromAProductUseCase';
+import { DeleteIngredientFromAProduct } from './dto/delete-ingredient-from-a-product-dto';
 
 @Controller('products')
 export class ProductController {
@@ -74,7 +75,7 @@ export class ProductController {
   @Delete('ingredients/:productId')
   async deleteIngredientFromAProduct(
     @Param('productId') productId: string,
-    @Body() ingredientId: string,
+    @Body() { ingredientId }: DeleteIngredientFromAProduct,
   ) {
     const deleteIngredientFromAProductUseCase =
       makeDeleteIngredientFromAProductUseCase();

--- a/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
+++ b/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
@@ -11,6 +11,10 @@ import { UpdateProductDTO } from '../../dto/update-product-dto';
 const prisma = new PrismaClient();
 
 export class PrismaProductsRepository implements ProductsRepository {
+  async delete(id: string): Promise<void> {
+    await prisma.product.delete({ where: { id } });
+  }
+
   async findAllIngredients(
     productId: string,
   ): Promise<ingredientsOnProducts[]> {

--- a/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
+++ b/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
@@ -7,10 +7,20 @@ import { CreateProductDto } from '../../dto/create-product-dto';
 import { IngredientsParams } from '../../dto/ingredients-params';
 import { ServiceUnavailableException } from '@nestjs/common';
 import { UpdateProductDTO } from '../../dto/update-product-dto';
+import { DeleteIngredientOnProductRequest } from '../../use-cases/delete-ingredient-from-a-product';
 
 const prisma = new PrismaClient();
 
 export class PrismaProductsRepository implements ProductsRepository {
+  async deleteIngredient({
+    ingredientId,
+    productId,
+  }: DeleteIngredientOnProductRequest) {
+    await prisma.ingredientsOnProducts.delete({
+      where: { productId_ingredientId: { ingredientId, productId } },
+    });
+  }
+
   async delete(id: string): Promise<void> {
     await prisma.product.delete({ where: { id } });
   }

--- a/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
+++ b/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
@@ -5,7 +5,7 @@ import {
 import { Prisma, PrismaClient, Product } from '@prisma/client';
 import { CreateProductDto } from '../../dto/create-product-dto';
 import { IngredientsParams } from '../../dto/ingredients-params';
-import { NotFoundException, ServiceUnavailableException } from '@nestjs/common';
+import { ServiceUnavailableException } from '@nestjs/common';
 import { UpdateProductDTO } from '../../dto/update-product-dto';
 import { DeleteIngredientOnProductRequest } from '../../use-cases/delete-ingredient-from-a-product';
 

--- a/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
+++ b/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
@@ -30,7 +30,7 @@ export class PrismaProductsRepository implements ProductsRepository {
   ): Promise<ingredientsOnProducts[]> {
     const ingredients = await prisma
       .$queryRaw<ingredientsOnProducts[]>(
-        Prisma.sql`select i.name, "ingredientsOnProducts".quantity,i."urlImage"
+        Prisma.sql`select i.id as ingredientId,i.name, "ingredientsOnProducts".quantity,i."urlImage"
                   from ingredients i, products p, "ingredientsOnProducts"
                   where p.id = ${productId}
                   and p.id = "ingredientsOnProducts"."productId"

--- a/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
+++ b/backend/src/modules/product/repositories/prisma/prisma-products-repository.ts
@@ -5,7 +5,7 @@ import {
 import { Prisma, PrismaClient, Product } from '@prisma/client';
 import { CreateProductDto } from '../../dto/create-product-dto';
 import { IngredientsParams } from '../../dto/ingredients-params';
-import { ServiceUnavailableException } from '@nestjs/common';
+import { NotFoundException, ServiceUnavailableException } from '@nestjs/common';
 import { UpdateProductDTO } from '../../dto/update-product-dto';
 import { DeleteIngredientOnProductRequest } from '../../use-cases/delete-ingredient-from-a-product';
 

--- a/backend/src/modules/product/repositories/products-repository.ts
+++ b/backend/src/modules/product/repositories/products-repository.ts
@@ -12,6 +12,8 @@ export interface ProductsRepository {
 
   update(id: string, data: UpdateProductDTO): Promise<Product>;
 
+  delete(id: string): void;
+
   changeAvailability(id: string): Promise<Product>;
 
   findOneById(id: string): Promise<Product | null>;

--- a/backend/src/modules/product/repositories/products-repository.ts
+++ b/backend/src/modules/product/repositories/products-repository.ts
@@ -1,6 +1,7 @@
 import { Product } from '@prisma/client';
 import { CreateProductDto } from '../dto/create-product-dto';
 import { UpdateProductDTO } from '../dto/update-product-dto';
+import { DeleteIngredientOnProductRequest } from '../use-cases/delete-ingredient-from-a-product';
 
 export interface ingredientsOnProducts {
   name: string;
@@ -13,6 +14,8 @@ export interface ProductsRepository {
   update(id: string, data: UpdateProductDTO): Promise<Product>;
 
   delete(id: string): void;
+
+  deleteIngredient(data: DeleteIngredientOnProductRequest): void;
 
   changeAvailability(id: string): Promise<Product>;
 

--- a/backend/src/modules/product/repositories/products-repository.ts
+++ b/backend/src/modules/product/repositories/products-repository.ts
@@ -4,8 +4,10 @@ import { UpdateProductDTO } from '../dto/update-product-dto';
 import { DeleteIngredientOnProductRequest } from '../use-cases/delete-ingredient-from-a-product';
 
 export interface ingredientsOnProducts {
+  ingredientid: string;
   name: string;
   quantity: number;
+  urlImage: string;
 }
 
 export interface ProductsRepository {

--- a/backend/src/modules/product/use-cases/delete-ingredient-from-a-product.ts
+++ b/backend/src/modules/product/use-cases/delete-ingredient-from-a-product.ts
@@ -26,6 +26,16 @@ export default class DeleteIngredientFromAProductUseCase {
       throw new NotFoundException(`Ingredient not found`);
     }
 
+    const ingredients = await this.productRepository.findAllIngredients(
+      product.id,
+    );
+
+    for (const ingredient of ingredients) {
+      if (ingredient.ingredientid !== ingredientId) {
+        throw new NotFoundException('Ingredient not in the product');
+      }
+    }
+
     return this.productRepository.deleteIngredient({ ingredientId, productId });
   }
 }

--- a/backend/src/modules/product/use-cases/delete-ingredient-from-a-product.ts
+++ b/backend/src/modules/product/use-cases/delete-ingredient-from-a-product.ts
@@ -1,0 +1,31 @@
+import IngredientsRepository from 'src/modules/ingredient/repositories/ingredients-repository';
+import { ProductsRepository } from '../repositories/products-repository';
+import { NotFoundException } from '@nestjs/common';
+
+export interface DeleteIngredientOnProductRequest {
+  ingredientId: string;
+  productId: string;
+}
+
+export default class DeleteIngredientFromAProductUseCase {
+  constructor(
+    private readonly productRepository: ProductsRepository,
+    private readonly ingredientsRepository: IngredientsRepository,
+  ) {}
+
+  async execute({ ingredientId, productId }: DeleteIngredientOnProductRequest) {
+    const product = await this.productRepository.findOneById(productId);
+
+    if (!product) {
+      throw new NotFoundException(`Product not found`);
+    }
+
+    const ingredient = await this.ingredientsRepository.findById(ingredientId);
+
+    if (!ingredient) {
+      throw new NotFoundException(`Ingredient not found`);
+    }
+
+    return this.productRepository.deleteIngredient({ ingredientId, productId });
+  }
+}

--- a/backend/src/modules/product/use-cases/delete.ts
+++ b/backend/src/modules/product/use-cases/delete.ts
@@ -1,0 +1,16 @@
+import { ProductsRepository } from '../repositories/products-repository';
+import { NotFoundException } from '@nestjs/common';
+
+export default class DeleteProductUseCase {
+  constructor(private readonly productRepository: ProductsRepository) {}
+
+  async execute(id: string) {
+    const product = await this.productRepository.findOneById(id);
+
+    if (!product) {
+      throw new NotFoundException(`Product not found`);
+    }
+
+    return this.productRepository.delete(product.id);
+  }
+}

--- a/backend/src/modules/product/use-cases/find-one-by-id.ts
+++ b/backend/src/modules/product/use-cases/find-one-by-id.ts
@@ -17,7 +17,7 @@ export default class FindOneByIdUseCase {
     const product = await this.productRepository.findOneById(id);
 
     if (!product) {
-      throw new NotFoundException(`Product with not found`);
+      throw new NotFoundException(`Product not found`);
     }
 
     const ingredients = await this.productRepository.findAllIngredients(

--- a/backend/src/modules/product/use-cases/update-product.ts
+++ b/backend/src/modules/product/use-cases/update-product.ts
@@ -30,7 +30,7 @@ export class UpdateProductUseCase {
       throw new NotFoundException('Product not found');
     }
 
-    if (data.name) {
+    if (data.name !== null) {
       const product = await this.productRepository.findByName(data.name);
 
       if (product.name !== data.name) {

--- a/backend/src/modules/product/use-cases/update-product.ts
+++ b/backend/src/modules/product/use-cases/update-product.ts
@@ -30,13 +30,11 @@ export class UpdateProductUseCase {
       throw new NotFoundException('Product not found');
     }
 
-    if (data.name !== null) {
+    if (data.name) {
       const product = await this.productRepository.findByName(data.name);
 
-      if (product.name !== data.name) {
-        if (product) {
-          throw new ConflictException('Product with this name already exists.');
-        }
+      if (product) {
+        throw new ConflictException('Product with this name already exists.');
       }
     }
 


### PR DESCRIPTION
- set onDelete CASCADE to IngredientsOnProducts and set categoryId on product as null onDelete
- imp delete product
- imp delete ingredient from a product
- rebase
- get ingredientId at query sql
- delete ingredient from a product

## Atualizações
- [x] Update schema do banco de dados
  - [x] Configurado onDelte como CASCADE na tabela auxiliar de igredientes em produtos
  - [x] Configurado onDelete como SetNull na tabela de produto no relacionamento com a Categoria definindo o campo como opcional para aceitar o método setNull
  - [x] Atualizando tipos das colunas de `valor do produto, valor total da mesa e total do pedido` para Decimal com 2 casas depois da vírgula 
- [x] Rota apagar um produto `DELETE /products/:productId`
- [x] Rotar remover um ingrediente de um produto `DELETE /products/ingredients/:productId`
